### PR TITLE
halon_transactions: Remove '-' in custom indexname for log_postdelivery

### DIFF
--- a/halon_transactions.hsl
+++ b/halon_transactions.hsl
@@ -293,7 +293,7 @@ function log_postdelivery($args, $opts = [])
     $indexname = "halon-transactions";
     if ($opts["indexname"])
     {
-        $indexname = $opts["indexname"]."-";
+        $indexname = $opts["indexname"];
     }
     $httpbulkid = "elastic";
     if ($opts["id"])


### PR DESCRIPTION
This is to ensure the same index is used between all log functions if a user specifies a custom index.